### PR TITLE
Fix windows install for Rust > 1.70 

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,7 @@ TOOLCHAIN ?= stable-msvc
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/libzoomerjoin.a
-PKG_LIBS = -L$(LIBDIR) -lzoomerjoin -lws2_32 -ladvapi32 -luserenv -lbcrypt
+PKG_LIBS = -L$(LIBDIR) -lzoomerjoin -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
 all: C_clean
 


### PR DESCRIPTION
Thanks @elaina-chen for bringing this to my attention in #52. [this blog post](https://yutani.rbind.io/post/rust-1.70-and-build-failure-on-windows/) does a great job explaining what the issue is. My understanding is that Rust 1.7 uses a new version of LLVM that does not play nice with the Windows build tools. I have changed the `PKG_LIBS` settings in the `Makevars` as suggested, which is making the package build properly on the Windows server I use. 