### PR TITLE
Win build

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -33,7 +33,7 @@ clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 
 rustup:
-	rustup toolchain install stable-win && \
-	rustup toolchain install stable-$(TARGET) && \
+	rustup toolchain install stable-gnu && \
+	# rustup toolchain install stable-$(TARGET) && \
 	rustup toolchain install stable-msvc \
     || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -34,6 +34,6 @@ clean:
 
 rustup:
 	rustup toolchain install stable-gnu && \
-	# rustup toolchain install stable-$(TARGET) && \
+	rustup toolchain install stable-$(TARGET) && \
 	rustup toolchain install stable-msvc \
     || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -32,4 +32,4 @@ clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 
 rustup:
-	rustup toolchain install $(TARGET) || true
+	rustup toolchain install stable-$(TARGET) || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,5 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+TARGET_BASE = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))
 
 # This is provided in Makevars.ucrt for R >= 4.2
 TOOLCHAIN ?= stable-msvc
@@ -32,4 +33,6 @@ clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 
 rustup:
-	rustup toolchain install stable-$(TARGET) || true
+	rustup toolchain install stable-$(TARGET) && \
+	rustup toolchain install stable-$(TARGET_BASE)-pc-windows-msvc && \
+    || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -34,5 +34,5 @@ clean:
 
 rustup:
 	rustup toolchain install stable-$(TARGET) && \
-	rustup toolchain install stable-$(TARGET_BASE)-pc-windows-msvc && \
+	rustup toolchain install stable-$(TARGET_BASE)-pc-windows-msvc \
     || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -8,7 +8,7 @@ LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/libzoomerjoin.a
 PKG_LIBS = -L$(LIBDIR) -lzoomerjoin -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
-all: C_clean
+all: C_clean rustup
 
 $(SHLIB): $(STATLIB)
 
@@ -30,3 +30,6 @@ C_clean:
 
 clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+
+rustup:
+    rustup toolchain install $(TARGET) || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -33,6 +33,7 @@ clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 
 rustup:
+	rustup toolchain install stable-win && \
 	rustup toolchain install stable-$(TARGET) && \
 	rustup toolchain install stable-msvc \
     || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -34,5 +34,5 @@ clean:
 
 rustup:
 	rustup toolchain install stable-$(TARGET) && \
-	rustup toolchain install stable-$(TARGET_BASE)-pc-windows-msvc \
+	rustup toolchain install stable-msvc \
     || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -34,6 +34,6 @@ clean:
 
 rustup:
 	rustup toolchain install stable-gnu && \
-	rustup toolchain install stable-$(TARGET) && \
-	rustup toolchain install stable-msvc \
+	rustup toolchain install stable-msvc && \
+	rustup target add $(TARGET) \
     || true

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -32,4 +32,4 @@ clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 
 rustup:
-    rustup toolchain install $(TARGET) || true
+	rustup toolchain install $(TARGET) || true


### PR DESCRIPTION
Installs the rust targets / toolchains for windows if they aren't already installed on the building machine. Hopefully this will make things build properly on r-universe. If it doesn't, I'll revert this change.