### PR TITLE
Minor speedup

### DIFF
--- a/R/string_group.R
+++ b/R/string_group.R
@@ -68,7 +68,7 @@ jaccard_string_group <- function(string, n_gram_width = 2, n_bands = 45, band_wi
     fc <- igraph::fastgreedy.community(igraph::as.undirected(graph))
 
     groups <- igraph::groups(fc)
-    lookup_table <- vapply(groups, function(x){x[[1]]}, integer(1))
+    lookup_table <- vapply(groups, "[[", integer(1), 1)
 
     membership <- igraph::membership(fc)
 


### PR DESCRIPTION
Hi, I just came across this possible optimization. Using anonymous functions is slower than using the function name. 

``` r
test <- rep(list(1:20), 1e7)

bench::mark(
  vapply(test, function(x){x[[1]]}, integer(1)),
  vapply(test, "[[", integer(1), 1),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 "vapply(test, function(x) { x[[1]] … 5.37s  5.52s     0.181    38.2MB     20.5
#> 2 "vapply(test, \"[[\", integer(1), 1… 3.34s  3.54s     0.282    38.1MB     20.3
```
This shouldn't change dramatically the speed of the function, but better than nothing.