### PR TITLE
Some speedup for `*_inner_join()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Empowers users to fuzzily-merge data frames with millions or tens o
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 SystemRequirements: Cargo (>= 1.56) (Rust's package manager), rustc
 Imports:
     dplyr,

--- a/R/euclidean_join_core.R
+++ b/R/euclidean_join_core.R
@@ -71,6 +71,12 @@ euclidean_join_core <- function (a, b, by = NULL, n_bands = 30, band_width = 10,
         paste0(names(b)[names(b) %in% names_in_both], ".y")
 
     matches <- dplyr::bind_cols(a[match_table[, 1], ], b[match_table[, 2], ])
+
+    # No need to look for rows that don't match
+    if (mode == "inner") {
+        return(matches)
+    }
+
     not_matched_a <- ! seq(nrow(a)) %in% match_table[,1]
     not_matched_b <- ! seq(nrow(b)) %in% match_table[,2]
 
@@ -80,8 +86,6 @@ euclidean_join_core <- function (a, b, by = NULL, n_bands = 30, band_width = 10,
         matches <- dplyr::bind_rows(matches,b[not_matched_b,])
     } else if (mode == "full") {
         matches <- dplyr::bind_rows(matches,a[not_matched_a,],b[not_matched_b,])
-    } else if (mode == "inner"){
-        matches <- matches
     } else if (mode == "anti") {
         matches <- dplyr::bind_rows(a[not_matched_a,], b[not_matched_b,])
     } else {

--- a/R/jaccard_join_core.R
+++ b/R/jaccard_join_core.R
@@ -142,13 +142,18 @@ jaccard_join <- function (a, b, mode, by, salt_by, n_gram_width, n_bands,
     names(b)[names(b) %in% names_in_both] <- paste0(names(b)[names(b) %in% names_in_both], ".y")
 
     matches <- dplyr::bind_cols(a[match_table[, 1], ], b[match_table[, 2], ])
-    not_matched_a <- ! seq(nrow(a)) %in% match_table[,1]
-    not_matched_b <- ! seq(nrow(b)) %in% match_table[,2]
 
     if(!is.null(similarity_column)) {
         matches[,similarity_column] <- similarities
     }
 
+    # No need to look for rows that don't match
+    if (mode == "inner") {
+        return(matches)
+    }
+
+    not_matched_a <- ! seq(nrow(a)) %in% match_table[,1]
+    not_matched_b <- ! seq(nrow(b)) %in% match_table[,2]
 
     if (mode == "left") {
         matches <- dplyr::bind_rows(matches,a[not_matched_a,])
@@ -156,8 +161,6 @@ jaccard_join <- function (a, b, mode, by, salt_by, n_gram_width, n_bands,
         matches <- dplyr::bind_rows(matches,b[not_matched_b,])
     } else if (mode == "full") {
         matches <- dplyr::bind_rows(matches,a[not_matched_a,],b[not_matched_b,])
-    } else if (mode == "inner"){
-        matches <- matches
     } else if (mode == "anti") {
         matches <- dplyr::bind_rows(a[not_matched_a,], b[not_matched_b,])
     } else {


### PR DESCRIPTION
Hi @beniaminogreen, here's a small PR that slightly improves the performance of `*_inner_join()` functions. For those functions, we don't need to get the indices of rows that don't match since they are not used in the output anyway. Small benchmark below (about 15% time decrease):

``` r
library(bench) 
library(dplyr)

out <- cross::run(
  pkgs = c("beniaminogreen/zoomerjoin", "etiennebacher/zoomerjoin@speedup-inner-join"), 
  ~{
    library(zoomerjoin)
    
    ### Setup -----
    
    corpus_1 <- data.table::rbindlist(rep(list(dime_data), 300))
    names(corpus_1) <- c("a", "field")
    print(nrow(corpus_1))
    
    corpus_2 <- data.table::rbindlist(rep(list(dime_data), 300))
    names(corpus_2) <- c("b", "field")
    
    ### Benchmark -----
    
    bench::mark(
      jaccard_inner_join(corpus_1, corpus_2, 
                        by = "field", n_gram_width=6,
                        n_bands=20, band_width=6, threshold = .8)
    )
  }
)

tidyr::unnest(out, result) |> 
  select(pkg, median, mem_alloc)
#> # A tibble: 2 × 3
#>   pkg                                           median mem_alloc
#>   <chr>                                       <bch:tm> <bch:byt>
#> 1 beniaminogreen/zoomerjoin                       3.7m    15.7GB
#> 2 etiennebacher/zoomerjoin@speedup-inner-join    3.21m    10.3GB
```
(the [`cross`](https://github.com/davisVaughan/cross) allows to run the same code on different branches, which is very useful for benchmarking)

---

Also worth noting that when getting the indices of unmatched rows is necessary, using `collapse::`%!iin%`` instead of `!%in%` would be more efficient (but would also add a dependency to the package)