### PR TITLE
Fix coercion to lower case when `clean = TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 # zoomerjoin (development version)
 
+## New features
+
 * Several performance improvements (#101, #104).
+
+## Bug fixes
+
+* When `clean = TRUE`, strings were not coerced to lower case. This is now the 
+  case (#105).
 
 # zoomerjoin 0.1.2
 

--- a/R/jaccard_join_core.R
+++ b/R/jaccard_join_core.R
@@ -88,8 +88,8 @@ jaccard_join <- function (a, b, mode, by, salt_by, n_gram_width, n_bands,
 
     # Clean strings that are matched on
     if (clean){
-        a_col <- gsub("[[:punct:] ]", "", dplyr::pull(a,by_a))
-        b_col <- gsub("[[:punct:] ]", "", dplyr::pull(b,by_b))
+        a_col <- tolower(gsub("[[:punct:] ]", "", dplyr::pull(a, by_a)))
+        b_col <- tolower(gsub("[[:punct:] ]", "", dplyr::pull(b, by_b)))
 
         if (!is.null(salt_by_a) && !is.null(salt_by_b)) {
             a_salt_col <- tidyr::unite(a,"salt_by_a", dplyr::all_of(salt_by_a)) %>%

--- a/R/jaccard_join_core.R
+++ b/R/jaccard_join_core.R
@@ -97,8 +97,8 @@ jaccard_join <- function (a, b, mode, by, salt_by, n_gram_width, n_bands,
             b_salt_col <- tidyr::unite(b,"salt_by_b", dplyr::all_of(salt_by_b)) %>%
                 dplyr::pull("salt_by_b")
 
-            a_salt_col <- gsub("[[:punct:] ]", "", a_salt_col)
-            b_salt_col <- gsub("[[:punct:] ]", "", b_salt_col)
+            a_salt_col <- tolower(gsub("[[:punct:] ]", "", a_salt_col))
+            b_salt_col <- tolower(gsub("[[:punct:] ]", "", b_salt_col))
         }
     } else{
         a_col <- dplyr::pull(a,by_a)


### PR DESCRIPTION
The docs say

> should the strings that you fuzzy join on be cleaned (coerced to lower-case, stripped of punctuation and spaces)? Default is FALSE

but strings were actually not coerced to lowercase (unless I missed something happening on the Rust side). This PR fixes that. Unfortunately I don't really see a good way to test this.