### PR TITLE
Use `styler::style_pkg()`

### DIFF
--- a/R/em_link.R
+++ b/R/em_link.R
@@ -35,40 +35,41 @@
 #'
 #' @examples
 #'
-#' inv_logit <- function (x) {
-#'    exp(x)/(1+exp(x))
-#'}
-#'n <- 10^6
-#'d <- 1:n %% 5 == 0
-#'X <- cbind(
-#'         as.integer(ifelse(d, runif(n)<.8, runif(n)<.2)),
-#'         as.integer(ifelse(d, runif(n)<.9, runif(n)<.2)),
-#'         as.integer(ifelse(d, runif(n)<.7, runif(n)<.2)),
-#'         as.integer(ifelse(d, runif(n)<.6, runif(n)<.2)),
-#'         as.integer(ifelse(d, runif(n)<.5, runif(n)<.2)),
-#'         as.integer(ifelse(d, runif(n)<.1, runif(n)<.9)),
-#'         as.integer(ifelse(d, runif(n)<.1, runif(n)<.9)),
-#'         as.integer(ifelse(d, runif(n)<.8, runif(n)<.01))
-#'         )
+#' inv_logit <- function(x) {
+#'   exp(x) / (1 + exp(x))
+#' }
+#' n <- 10^6
+#' d <- 1:n %% 5 == 0
+#' X <- cbind(
+#'   as.integer(ifelse(d, runif(n) < .8, runif(n) < .2)),
+#'   as.integer(ifelse(d, runif(n) < .9, runif(n) < .2)),
+#'   as.integer(ifelse(d, runif(n) < .7, runif(n) < .2)),
+#'   as.integer(ifelse(d, runif(n) < .6, runif(n) < .2)),
+#'   as.integer(ifelse(d, runif(n) < .5, runif(n) < .2)),
+#'   as.integer(ifelse(d, runif(n) < .1, runif(n) < .9)),
+#'   as.integer(ifelse(d, runif(n) < .1, runif(n) < .9)),
+#'   as.integer(ifelse(d, runif(n) < .8, runif(n) < .01))
+#' )
 #'
 #' # inital guess at class assignments based on # a hypothetical logistic
 #' # regression. Should be based on domain knowledge, or a handful of hand-coded
 #' # observations.
 #'
-#'x_sum <- rowSums(X)
-#'g <- inv_logit((x_sum - mean(x_sum))/sd(x_sum))
+#' x_sum <- rowSums(X)
+#' g <- inv_logit((x_sum - mean(x_sum)) / sd(x_sum))
 #'
-#' out <- em_link(X, g,tol=.0001, max_iter = 100)
+#' out <- em_link(X, g, tol = .0001, max_iter = 100)
 #'
 #' @export
-em_link <- function (X,g, tol = 10^-6, max_iter = 10^3) {
+em_link <- function(X, g, tol = 10^-6, max_iter = 10^3) {
+  stopifnot(
+    "There can be no NA's in X (but you can add NA as its own agreement level)" = !any(is.na(X))
+  )
 
-    stopifnot("There can be no NA's in X (but you can add NA as its own agreement level)"
-              = !any(is.na(X)))
-
-    stopifnot("initial guesses must be valid probabilities (greater than 0 and less than 1)"
-              = all(g < 1 & g > 0))
+  stopifnot(
+    "initial guesses must be valid probabilities (greater than 0 and less than 1)" = all(g < 1 & g > 0)
+  )
 
 
-    rust_em_link(X,g, tol, max_iter)
+  rust_em_link(X, g, tol, max_iter)
 }

--- a/R/euclidean_join_core.R
+++ b/R/euclidean_join_core.R
@@ -1,95 +1,96 @@
-multi_by_validate <- function(a,b, by) {
-    # first pass to handle dplyr::join_by() call
-    if (inherits(by, "dplyr_join_by")) {
-        if (any(by$condition != "==")) {
-            stop("Inequality joins are not supported.")
-        }
-        new_by <- by$y
-        names(new_by) <- by$x
-        by <- new_by
+multi_by_validate <- function(a, b, by) {
+  # first pass to handle dplyr::join_by() call
+  if (inherits(by, "dplyr_join_by")) {
+    if (any(by$condition != "==")) {
+      stop("Inequality joins are not supported.")
     }
+    new_by <- by$y
+    names(new_by) <- by$x
+    by <- new_by
+  }
 
-    if (is.null(by)) {
-        by_a <- intersect(names(a), names(b))
-        by_b <- intersect(names(a), names(b))
+  if (is.null(by)) {
+    by_a <- intersect(names(a), names(b))
+    by_b <- intersect(names(a), names(b))
+  } else {
+    if (!is.null(names(by))) {
+      by_a <- names(by)
+      by_b <- by
     } else {
-        if (!is.null(names(by))) {
-            by_a <- names(by)
-            by_b <- by
-        } else {
-            by_a <- by
-            by_b <- by
-        }
-
-        stopifnot(by_a %in% names(a))
-        stopifnot(by_b %in% names(b))
+      by_a <- by
+      by_b <- by
     }
-    return(list(
-                by_a,
-                by_b
-                ))
+
+    stopifnot(by_a %in% names(a))
+    stopifnot(by_b %in% names(b))
+  }
+  return(list(
+    by_a,
+    by_b
+  ))
 }
 
-#` @importFrom stats pnorm
-euclidean_join_core <- function (a, b, by = NULL, n_bands = 30, band_width = 10, threshold=1.0, r=.5, progress = FALSE, mode="inner") {
+# ` @importFrom stats pnorm
+euclidean_join_core <- function(a, b, by = NULL, n_bands = 30, band_width = 10, threshold = 1.0, r = .5, progress = FALSE, mode = "inner") {
+  stopifnot("'radius' must be greater than 0" = threshold > 0)
 
-    stopifnot("'radius' must be greater than 0" = threshold > 0)
+  by <- multi_by_validate(a, b, by)
+  by_a <- by[[1]]
+  by_b <- by[[2]]
+  stopifnot("There should be no NA's in by_a[1]" = !any(is.na(dplyr::pull(a, by_a[1]))))
+  stopifnot("There should be no NA's in by_a[2]" = !any(is.na(dplyr::pull(a, by_a[2]))))
+  stopifnot("There should be no NA's in by_b[1]" = !any(is.na(dplyr::pull(b, by_b[1]))))
+  stopifnot("There should be no NA's in by_b[2]" = !any(is.na(dplyr::pull(b, by_b[2]))))
 
-    by <- multi_by_validate(a,b,by)
-    by_a <- by[[1]]
-    by_b <- by[[2]]
-    stopifnot("There should be no NA's in by_a[1]"=!any(is.na(dplyr::pull(a,by_a[1]))))
-    stopifnot("There should be no NA's in by_a[2]"=!any(is.na(dplyr::pull(a,by_a[2]))))
-    stopifnot("There should be no NA's in by_b[1]"=!any(is.na(dplyr::pull(b,by_b[1]))))
-    stopifnot("There should be no NA's in by_b[2]"=!any(is.na(dplyr::pull(b,by_b[2]))))
-
-    thresh_prob <- euclidean_probability(threshold, n_bands, band_width, r)
-    if (thresh_prob < .95) {
-        str <- paste0("A pair of records at the threshold (", threshold,
-                     ") have only a ", round(thresh_prob*100), "% chance of being compared.\n",
-                     "Please consider changing `n_bands` and `band_width`, and `r`.")
-
-        warning(str)
-    }
-
-    match_table <- rust_p_norm_join(
-                                a_mat = as.matrix(dplyr::select(a, dplyr::all_of(by_a))),
-                                b_mat = as.matrix(dplyr::select(b, dplyr::all_of(by_b))),
-                                radius = threshold,
-                                band_width = band_width,
-                                n_bands = n_bands,
-                                r = r,
-                                progress = progress,
-                                seed = round(runif(1,0,2^32))
+  thresh_prob <- euclidean_probability(threshold, n_bands, band_width, r)
+  if (thresh_prob < .95) {
+    str <- paste0(
+      "A pair of records at the threshold (", threshold,
+      ") have only a ", round(thresh_prob * 100), "% chance of being compared.\n",
+      "Please consider changing `n_bands` and `band_width`, and `r`."
     )
 
-    names_in_both <- intersect(names(a), names(b))
+    warning(str)
+  }
 
-    names(a)[names(a) %in% names_in_both] <-
-        paste0(names(a)[names(a) %in% names_in_both], ".x")
-    names(b)[names(b) %in% names_in_both] <-
-        paste0(names(b)[names(b) %in% names_in_both], ".y")
+  match_table <- rust_p_norm_join(
+    a_mat = as.matrix(dplyr::select(a, dplyr::all_of(by_a))),
+    b_mat = as.matrix(dplyr::select(b, dplyr::all_of(by_b))),
+    radius = threshold,
+    band_width = band_width,
+    n_bands = n_bands,
+    r = r,
+    progress = progress,
+    seed = round(runif(1, 0, 2^32))
+  )
 
-    matches <- dplyr::bind_cols(a[match_table[, 1], ], b[match_table[, 2], ])
+  names_in_both <- intersect(names(a), names(b))
 
-    # No need to look for rows that don't match
-    if (mode == "inner") {
-        return(matches)
-    }
+  names(a)[names(a) %in% names_in_both] <-
+    paste0(names(a)[names(a) %in% names_in_both], ".x")
+  names(b)[names(b) %in% names_in_both] <-
+    paste0(names(b)[names(b) %in% names_in_both], ".y")
 
-    not_matched_a <- ! seq(nrow(a)) %in% match_table[,1]
-    not_matched_b <- ! seq(nrow(b)) %in% match_table[,2]
+  matches <- dplyr::bind_cols(a[match_table[, 1], ], b[match_table[, 2], ])
 
-    if (mode == "left") {
-        matches <- dplyr::bind_rows(matches,a[not_matched_a,])
-    } else if (mode == "right") {
-        matches <- dplyr::bind_rows(matches,b[not_matched_b,])
-    } else if (mode == "full") {
-        matches <- dplyr::bind_rows(matches,a[not_matched_a,],b[not_matched_b,])
-    } else if (mode == "anti") {
-        matches <- dplyr::bind_rows(a[not_matched_a,], b[not_matched_b,])
-    } else {
-        stop("Invalid Mode Selected!")
-    }
+  # No need to look for rows that don't match
+  if (mode == "inner") {
     return(matches)
+  }
+
+  not_matched_a <- !seq(nrow(a)) %in% match_table[, 1]
+  not_matched_b <- !seq(nrow(b)) %in% match_table[, 2]
+
+  if (mode == "left") {
+    matches <- dplyr::bind_rows(matches, a[not_matched_a, ])
+  } else if (mode == "right") {
+    matches <- dplyr::bind_rows(matches, b[not_matched_b, ])
+  } else if (mode == "full") {
+    matches <- dplyr::bind_rows(matches, a[not_matched_a, ], b[not_matched_b, ])
+  } else if (mode == "anti") {
+    matches <- dplyr::bind_rows(a[not_matched_a, ], b[not_matched_b, ])
+  } else {
+    stop("Invalid Mode Selected!")
+  }
+  return(matches)
 }

--- a/R/jaccard_join_core.R
+++ b/R/jaccard_join_core.R
@@ -1,178 +1,180 @@
-simple_by_validate <- function(a,b, by) {
-    # first pass to handle dplyr::join_by() call
-    if (inherits(by, "dplyr_join_by")) {
-        if (any(by$condition != "==")) {
-            stop("Inequality joins are not supported.")
-        }
-        new_by <- by$y
-        names(new_by) <- by$x
-        by <- new_by
+simple_by_validate <- function(a, b, by) {
+  # first pass to handle dplyr::join_by() call
+  if (inherits(by, "dplyr_join_by")) {
+    if (any(by$condition != "==")) {
+      stop("Inequality joins are not supported.")
     }
+    new_by <- by$y
+    names(new_by) <- by$x
+    by <- new_by
+  }
 
-    if (is.null(by)) {
-        by_a <- intersect(names(a), names(b))
-        by_b <- intersect(names(a), names(b))
-        stopifnot("Can't Determine Column to Match on" = length(by_a)==1)
-        message(paste0("Joining by '", by_a, "'\n"))
+  if (is.null(by)) {
+    by_a <- intersect(names(a), names(b))
+    by_b <- intersect(names(a), names(b))
+    stopifnot("Can't Determine Column to Match on" = length(by_a) == 1)
+    message(paste0("Joining by '", by_a, "'\n"))
+  } else {
+    if (!is.null(names(by))) {
+      by_a <- names(by)
+      by_b <- unname(by)
     } else {
-        if (!is.null(names(by))) {
-            by_a <- names(by)
-            by_b <- unname(by)
-        } else {
-            by_a <- by
-            by_b <- by
-        }
-
-        stopifnot(by_a %in% names(a))
-        stopifnot(by_b %in% names(b))
+      by_a <- by
+      by_b <- by
     }
-    return(list(
-                by_a,
-                by_b
-                ))
+
+    stopifnot(by_a %in% names(a))
+    stopifnot(by_b %in% names(b))
+  }
+  return(list(
+    by_a,
+    by_b
+  ))
 }
 
 #' @importFrom dplyr pull %>%
-jaccard_join <- function (a, b, mode, by, salt_by, n_gram_width, n_bands,
-                      band_width, threshold, progress = FALSE, a_salt = NULL, b_salt = NULL,
-                      clean=FALSE, similarity_column = NULL) {
+jaccard_join <- function(a, b, mode, by, salt_by, n_gram_width, n_bands,
+                         band_width, threshold, progress = FALSE, a_salt = NULL, b_salt = NULL,
+                         clean = FALSE, similarity_column = NULL) {
+  a <- tibble::as_tibble(a)
+  b <- tibble::as_tibble(b)
 
-    a <- tibble::as_tibble(a)
-    b <- tibble::as_tibble(b)
+  stopifnot("'threshold' must be of length 1" = length(threshold) == 1)
+  stopifnot("'threshold' must be between 0 and 1" = threshold <= 1 & threshold >= 0)
 
-    stopifnot("'threshold' must be of length 1" = length(threshold) == 1)
-    stopifnot("'threshold' must be between 0 and 1" = threshold <= 1 & threshold>=0)
+  stopifnot("'n_bands' must be greater than 0" = n_bands > 0)
+  stopifnot("'n_bands' must be length than 1" = length(n_bands) == 1)
 
-    stopifnot("'n_bands' must be greater than 0" = n_bands > 0)
-    stopifnot("'n_bands' must be length than 1" = length(n_bands) == 1)
+  stopifnot("'band_width' must be greater than 0" = band_width > 0)
+  stopifnot("'band_width' must be length than 1" = length(band_width) == 1)
 
-    stopifnot("'band_width' must be greater than 0" = band_width > 0)
-    stopifnot("'band_width' must be length than 1" = length(band_width) == 1)
+  stopifnot("'n_gram_width' must be greater than 0" = n_gram_width > 0)
+  stopifnot("'n_gram_width' must be length than 1" = length(n_gram_width) == 1)
 
-    stopifnot("'n_gram_width' must be greater than 0" = n_gram_width > 0)
-    stopifnot("'n_gram_width' must be length than 1" = length(n_gram_width) == 1)
+  thresh_prob <- jaccard_probability(threshold, n_bands, band_width)
 
-    thresh_prob <- jaccard_probability(threshold, n_bands, band_width)
-
-    if (thresh_prob < .95) {
-        str <- paste0("A pair of records at the threshold (", threshold,
-                     ") have only a ", round(thresh_prob*100), "% chance of being compared.\n",
-                     "Please consider changing `n_bands` and `band_width`.")
-
-        warning(str)
-    }
-
-
-
-    by <- simple_by_validate(a,b,by)
-    by_a <- by[[1]]
-    by_b <- by[[2]]
-    stopifnot("'by' vectors must have length 1" = length(by_a)==1)
-    stopifnot("'by' vectors must have length 1" = length(by_b)==1)
-
-    stopifnot("There should be no NA's in by_a"=!any(is.na(dplyr::pull(a,by_a))))
-    stopifnot("There should be no NA's in by_b"=!any(is.na(dplyr::pull(b,by_b))))
-
-    salt_by_a <- NULL
-    salt_by_b <- NULL
-    # don't impute salt_by
-    if (!is.null(salt_by)) {
-        salt_by <- simple_by_validate(a,b,salt_by)
-        salt_by_a <- salt_by[[1]]
-        salt_by_b <- salt_by[[2]]
-        stopifnot("There should be no NA's in the blocking variables"=!
-                  any(is.na(dplyr::select(a,dplyr::all_of(salt_by_a)))))
-        stopifnot("There should be no NA's in the blocking variables"=!
-                  any(is.na(dplyr::select(b,dplyr::all_of(salt_by_b)))))
-    }
-
-    # Clean strings that are matched on
-    if (clean){
-        a_col <- tolower(gsub("[[:punct:] ]", "", dplyr::pull(a, by_a)))
-        b_col <- tolower(gsub("[[:punct:] ]", "", dplyr::pull(b, by_b)))
-
-        if (!is.null(salt_by_a) && !is.null(salt_by_b)) {
-            a_salt_col <- tidyr::unite(a,"salt_by_a", dplyr::all_of(salt_by_a)) %>%
-                dplyr::pull("salt_by_a")
-            b_salt_col <- tidyr::unite(b,"salt_by_b", dplyr::all_of(salt_by_b)) %>%
-                dplyr::pull("salt_by_b")
-
-            a_salt_col <- tolower(gsub("[[:punct:] ]", "", a_salt_col))
-            b_salt_col <- tolower(gsub("[[:punct:] ]", "", b_salt_col))
-        }
-    } else{
-        a_col <- dplyr::pull(a,by_a)
-        b_col <- dplyr::pull(b,by_b)
-
-        if (!is.null(salt_by_a) && !is.null(salt_by_b)) {
-
-            a_salt_col <- tidyr::unite(a,"salt_by_a", dplyr::all_of(salt_by_a)) %>%
-                dplyr::pull("salt_by_a")
-
-            b_salt_col <- tidyr::unite(b,"salt_by_b", dplyr::all_of(salt_by_b)) %>%
-                dplyr::pull("salt_by_b")
-        }
-    }
-
-    if (is.null(salt_by_a) | is.null(salt_by_b)) {
-        match_table <- rust_jaccard_join(
-                 a_col, b_col,
-                 n_gram_width, n_bands, band_width, threshold,
-                 progress, seed = 1)
-    } else {
-        match_table <- rust_salted_jaccard_join(
-                 a_col, b_col,
-                 a_salt_col, b_salt_col,
-                 n_gram_width, n_bands, band_width, threshold,
-                 progress, seed = round(runif(1,0,2^64))
-        )
-    }
-
-    if (!is.null(similarity_column)) {
-         similarities <- jaccard_similarity(
-                           pull(a[match_table[, 1],], by_a),
-                           pull(b[match_table[, 2],],by_b),
-                           n_gram_width
-        )
-    }
-
-    # Rename Columns in Both Tables
-    names_in_both <- intersect(names(a), names(b))
-    names(a)[names(a) %in% names_in_both] <- paste0(names(a)[names(a) %in% names_in_both], ".x")
-    names(b)[names(b) %in% names_in_both] <- paste0(names(b)[names(b) %in% names_in_both], ".y")
-
-    matches <- dplyr::bind_cols(a[match_table[, 1], ], b[match_table[, 2], ])
-
-    if(!is.null(similarity_column)) {
-        matches[,similarity_column] <- similarities
-    }
-
-    # No need to look for rows that don't match
-    if (mode == "inner") {
-        return(matches)
-    }
-
-    switch(
-        mode,
-        "left" = {
-            not_matched_a <- collapse::`%!iin%`(seq(nrow(a)), match_table[, 1])
-            matches <- dplyr::bind_rows(matches, a[not_matched_a,])
-        },
-        "right" = {
-            not_matched_b <- collapse::`%!iin%`(seq(nrow(b)), match_table[, 2])
-            matches <- dplyr::bind_rows(matches, b[not_matched_b,])
-        },
-        "full" = {
-            not_matched_a <- collapse::`%!iin%`(seq(nrow(a)), match_table[, 1])
-            not_matched_b <- collapse::`%!iin%`(seq(nrow(b)), match_table[, 2])
-            matches <- dplyr::bind_rows(matches, a[not_matched_a,], b[not_matched_b,])
-        },
-        "anti" = {
-            not_matched_a <- collapse::`%!iin%`(seq(nrow(a)), match_table[, 1])
-            not_matched_b <- collapse::`%!iin%`(seq(nrow(b)), match_table[, 2])
-            matches <- dplyr::bind_rows(a[not_matched_a,], b[not_matched_b,])
-        }
+  if (thresh_prob < .95) {
+    str <- paste0(
+      "A pair of records at the threshold (", threshold,
+      ") have only a ", round(thresh_prob * 100), "% chance of being compared.\n",
+      "Please consider changing `n_bands` and `band_width`."
     )
 
-    matches
+    warning(str)
+  }
+
+
+
+  by <- simple_by_validate(a, b, by)
+  by_a <- by[[1]]
+  by_b <- by[[2]]
+  stopifnot("'by' vectors must have length 1" = length(by_a) == 1)
+  stopifnot("'by' vectors must have length 1" = length(by_b) == 1)
+
+  stopifnot("There should be no NA's in by_a" = !any(is.na(dplyr::pull(a, by_a))))
+  stopifnot("There should be no NA's in by_b" = !any(is.na(dplyr::pull(b, by_b))))
+
+  salt_by_a <- NULL
+  salt_by_b <- NULL
+  # don't impute salt_by
+  if (!is.null(salt_by)) {
+    salt_by <- simple_by_validate(a, b, salt_by)
+    salt_by_a <- salt_by[[1]]
+    salt_by_b <- salt_by[[2]]
+    stopifnot("There should be no NA's in the blocking variables" = !
+    any(is.na(dplyr::select(a, dplyr::all_of(salt_by_a)))))
+    stopifnot("There should be no NA's in the blocking variables" = !
+    any(is.na(dplyr::select(b, dplyr::all_of(salt_by_b)))))
+  }
+
+  # Clean strings that are matched on
+  if (clean) {
+    a_col <- tolower(gsub("[[:punct:] ]", "", dplyr::pull(a, by_a)))
+    b_col <- tolower(gsub("[[:punct:] ]", "", dplyr::pull(b, by_b)))
+
+    if (!is.null(salt_by_a) && !is.null(salt_by_b)) {
+      a_salt_col <- tidyr::unite(a, "salt_by_a", dplyr::all_of(salt_by_a)) %>%
+        dplyr::pull("salt_by_a")
+      b_salt_col <- tidyr::unite(b, "salt_by_b", dplyr::all_of(salt_by_b)) %>%
+        dplyr::pull("salt_by_b")
+
+      a_salt_col <- tolower(gsub("[[:punct:] ]", "", a_salt_col))
+      b_salt_col <- tolower(gsub("[[:punct:] ]", "", b_salt_col))
+    }
+  } else {
+    a_col <- dplyr::pull(a, by_a)
+    b_col <- dplyr::pull(b, by_b)
+
+    if (!is.null(salt_by_a) && !is.null(salt_by_b)) {
+      a_salt_col <- tidyr::unite(a, "salt_by_a", dplyr::all_of(salt_by_a)) %>%
+        dplyr::pull("salt_by_a")
+
+      b_salt_col <- tidyr::unite(b, "salt_by_b", dplyr::all_of(salt_by_b)) %>%
+        dplyr::pull("salt_by_b")
+    }
+  }
+
+  if (is.null(salt_by_a) | is.null(salt_by_b)) {
+    match_table <- rust_jaccard_join(
+      a_col, b_col,
+      n_gram_width, n_bands, band_width, threshold,
+      progress,
+      seed = 1
+    )
+  } else {
+    match_table <- rust_salted_jaccard_join(
+      a_col, b_col,
+      a_salt_col, b_salt_col,
+      n_gram_width, n_bands, band_width, threshold,
+      progress,
+      seed = round(runif(1, 0, 2^64))
+    )
+  }
+
+  if (!is.null(similarity_column)) {
+    similarities <- jaccard_similarity(
+      pull(a[match_table[, 1], ], by_a),
+      pull(b[match_table[, 2], ], by_b),
+      n_gram_width
+    )
+  }
+
+  # Rename Columns in Both Tables
+  names_in_both <- intersect(names(a), names(b))
+  names(a)[names(a) %in% names_in_both] <- paste0(names(a)[names(a) %in% names_in_both], ".x")
+  names(b)[names(b) %in% names_in_both] <- paste0(names(b)[names(b) %in% names_in_both], ".y")
+
+  matches <- dplyr::bind_cols(a[match_table[, 1], ], b[match_table[, 2], ])
+
+  if (!is.null(similarity_column)) {
+    matches[, similarity_column] <- similarities
+  }
+
+  # No need to look for rows that don't match
+  if (mode == "inner") {
+    return(matches)
+  }
+
+  switch(mode,
+    "left" = {
+      not_matched_a <- collapse::`%!iin%`(seq(nrow(a)), match_table[, 1])
+      matches <- dplyr::bind_rows(matches, a[not_matched_a, ])
+    },
+    "right" = {
+      not_matched_b <- collapse::`%!iin%`(seq(nrow(b)), match_table[, 2])
+      matches <- dplyr::bind_rows(matches, b[not_matched_b, ])
+    },
+    "full" = {
+      not_matched_a <- collapse::`%!iin%`(seq(nrow(a)), match_table[, 1])
+      not_matched_b <- collapse::`%!iin%`(seq(nrow(b)), match_table[, 2])
+      matches <- dplyr::bind_rows(matches, a[not_matched_a, ], b[not_matched_b, ])
+    },
+    "anti" = {
+      not_matched_a <- collapse::`%!iin%`(seq(nrow(a)), match_table[, 1])
+      not_matched_b <- collapse::`%!iin%`(seq(nrow(b)), match_table[, 2])
+      matches <- dplyr::bind_rows(a[not_matched_a, ], b[not_matched_b, ])
+    }
+  )
+
+  matches
 }

--- a/R/jaccard_similarity.R
+++ b/R/jaccard_similarity.R
@@ -9,11 +9,13 @@
 #' @return a vector of jaccard similarities of the strings
 #'
 #' @examples
-#' jaccard_similarity(c("the quick brown fox","jumped over the lazy dog"),
-#'     c("the quck bron fx","jumped over hte lazy dog"))
+#' jaccard_similarity(
+#'   c("the quick brown fox", "jumped over the lazy dog"),
+#'   c("the quck bron fx", "jumped over hte lazy dog")
+#' )
 #'
 #' @export
-jaccard_similarity <- function(a, b, ngram_width=2) {
-    stopifnot(length(a) == length(b))
-    rust_jaccard_similarity(a, b, ngram_width)
+jaccard_similarity <- function(a, b, ngram_width = 2) {
+  stopifnot(length(a) == length(b))
+  rust_jaccard_similarity(a, b, ngram_width)
 }

--- a/R/lsh_properties.R
+++ b/R/lsh_properties.R
@@ -10,27 +10,26 @@
 #' @examples
 #' # Plot the probability two pairs will be matched as a function of their
 #' # jaccard similarity, given the hyperparameters n_bands and band_width.
-#' jaccard_curve(40,6)
+#' jaccard_curve(40, 6)
 #'
 #' @export
 jaccard_curve <- function(n_bands, band_width) {
+  stopifnot("number of bands must be a single integer" = length(n_bands) == 1)
+  stopifnot("band width must be a single integer" = length(band_width) == 1)
 
-    stopifnot("number of bands must be a single integer" = length(n_bands)==1)
-    stopifnot("band width must be a single integer" = length(band_width)==1)
+  stopifnot(n_bands > 0)
+  stopifnot(band_width > 0)
 
-    stopifnot(n_bands > 0)
-    stopifnot(band_width > 0)
+  similarity <- seq(0, 1, .005)
 
-    similarity <- seq(0,1,.005)
+  probs <- 1 - (1 - similarity^band_width)^n_bands
 
-    probs <- 1-(1-similarity^band_width)^n_bands
-
-    plot(similarity, probs,
-         xlab = "Jaccard Similarity of Two Strings",
-         ylab = "Probability that Strings are Proposed as a Match",
-         type="l",
-         col = "blue"
-    )
+  plot(similarity, probs,
+    xlab = "Jaccard Similarity of Two Strings",
+    ylab = "Probability that Strings are Proposed as a Match",
+    type = "l",
+    col = "blue"
+  )
 }
 
 #' Find Probability of Match Based on Similarity
@@ -58,8 +57,8 @@ jaccard_curve <- function(n_bands, band_width) {
 #' # jaccard_similarity of .8, band width of 5, and 50 bands:
 #' jaccard_probability(.8, n_bands = 50, band_width = 5)
 #' @export
-jaccard_probability <- function(similarity, n_bands, band_width){
-    1-(1-similarity^band_width)^n_bands
+jaccard_probability <- function(similarity, n_bands, band_width) {
+  1 - (1 - similarity^band_width)^n_bands
 }
 
 #' Plot S-Curve for a LSH with given hyperparameters
@@ -76,16 +75,16 @@ jaccard_probability <- function(similarity, n_bands, band_width){
 #' the Jaccard similarity of the two items.
 #'
 euclidean_curve <- function(n_bands, band_width, r, up_to = 100) {
-    x <- seq(0, up_to, length.out=1500)
-    y <- euclidean_probability(x, n_bands, band_width,r)
+  x <- seq(0, up_to, length.out = 1500)
+  y <- euclidean_probability(x, n_bands, band_width, r)
 
 
-    plot(x, y,
-         xlab = "Euclidian Distance Between Two Vectors",
-         ylab = "Probability that Vectors are Proposed as a Match",
-         type="l",
-         col = "blue"
-    )
+  plot(x, y,
+    xlab = "Euclidian Distance Between Two Vectors",
+    ylab = "Probability that Vectors are Proposed as a Match",
+    type = "l",
+    col = "blue"
+  )
 }
 
 #' Find Probability of Match Based on Similarity
@@ -105,9 +104,9 @@ euclidean_curve <- function(n_bands, band_width, r, up_to = 100) {
 #' @importFrom stats pnorm
 #' @export
 euclidean_probability <- function(distance, n_bands, band_width, r) {
-    p <- 1 - 2*pnorm(-r/distance) - 2/(sqrt(2*pi)*r/distance)*(1-exp(-(r^2/(2*distance^2))))
+  p <- 1 - 2 * pnorm(-r / distance) - 2 / (sqrt(2 * pi) * r / distance) * (1 - exp(-(r^2 / (2 * distance^2))))
 
-    1 - (1-p^band_width)^n_bands
+  1 - (1 - p^band_width)^n_bands
 }
 
 
@@ -134,41 +133,36 @@ euclidean_probability <- function(distance, n_bands, band_width, r) {
 #' # Help me find the parameters that will minimize runtime while ensuring that
 #' # two strings with similarity .1 will be compared less than .1% of the time,
 #' # strings with .8 similaity will have a 99.95% chance of being compared:
-#' jaccard_hyper_grid_search(.1,.9,.001,.995)
+#' jaccard_hyper_grid_search(.1, .9, .001, .995)
 #'
 #' @export
-jaccard_hyper_grid_search <- function(s1=.1,s2=.7,p1=.001,p2=.999) {
+jaccard_hyper_grid_search <- function(s1 = .1, s2 = .7, p1 = .001, p2 = .999) {
+  stopifnot("s1 must be a single number" = length(s1) == 1)
+  stopifnot("s2 must be a single number" = length(s2) == 1)
+  stopifnot("p1 must be a single number" = length(p1) == 1)
+  stopifnot("p2 must be a single number" = length(p2) == 1)
 
-    stopifnot("s1 must be a single number"=length(s1)==1)
-    stopifnot("s2 must be a single number"=length(s2)==1)
-    stopifnot("p1 must be a single number"=length(p1)==1)
-    stopifnot("p2 must be a single number"=length(p2)==1)
+  stopifnot("similarity 1 must be less than similarity 2" = s1 < s2)
+  stopifnot("proability 1 must be less than similarity 2" = p1 < p2)
 
-    stopifnot("similarity 1 must be less than similarity 2" = s1 < s2)
-    stopifnot("proability 1 must be less than similarity 2" = p1 < p2)
+  df <- expand.grid(
+    band_width = seq(1, 75, 1),
+    n_bands = seq(1, 50000, 1)
+  )
 
-    df <- expand.grid(
-                band_width = seq(1,75,1),
-                n_bands = seq(1,50000,1)
-            )
+  df$p1 <- jaccard_probability(s1, n_bands = df$n_bands, band_width = df$band_width)
+  df$p2 <- jaccard_probability(s2, n_bands = df$n_bands, band_width = df$band_width)
 
-    df$p1 <-jaccard_probability(s1, n_bands = df$n_bands,  band_width = df$band_width)
-    df$p2 <-jaccard_probability(s2, n_bands = df$n_bands,  band_width = df$band_width)
+  df$feasible <- (df$p1 < p1) & (df$p2 > p2)
 
-    df$feasible <- (df$p1 < p1) & (df$p2 > p2)
+  df$prod <- df$band_width * df$n_bands
 
-    df$prod <- df$band_width * df$n_bands
+  df <- df[df$feasible, ]
 
-    df <- df[df$feasible,]
+  selected <- which.min(df$prod)
 
-    selected <- which.min(df$prod)
-
-    return(c(
-        "band_width" = df$band_width[selected] ,
-        "n_bands" = df$n_bands[selected]
-      ))
-
+  return(c(
+    "band_width" = df$band_width[selected],
+    "n_bands" = df$n_bands[selected]
+  ))
 }
-
-
-

--- a/R/on_load.R
+++ b/R/on_load.R
@@ -1,8 +1,8 @@
 .onAttach <- function(libname, pkgname) {
-    if(Sys.getenv("_R_CHECK_LIMIT_CORES_")!= "") {
-        if(as.logical(Sys.getenv("_R_CHECK_LIMIT_CORES_"))) {
-            packageStartupMessage("_R_CHECK_LIMIT_CORES_ is set to TRUE. Running on 2 cores")
-            Sys.setenv("RAYON_NUM_THREADS" = 2)
-        }
+  if (Sys.getenv("_R_CHECK_LIMIT_CORES_") != "") {
+    if (as.logical(Sys.getenv("_R_CHECK_LIMIT_CORES_"))) {
+      packageStartupMessage("_R_CHECK_LIMIT_CORES_ is set to TRUE. Running on 2 cores")
+      Sys.setenv("RAYON_NUM_THREADS" = 2)
     }
+  }
 }

--- a/R/string_group.R
+++ b/R/string_group.R
@@ -42,42 +42,43 @@
 #'
 #' @examples
 #'
-#' string <- c("beniamino", "jack", "benjamin", "beniamin",
-#'     "jacky", "giacomo", "gaicomo")
-#' jaccard_string_group(string, threshold = .2, n_bands=90, n_gram_width=1)
+#' string <- c(
+#'   "beniamino", "jack", "benjamin", "beniamin",
+#'   "jacky", "giacomo", "gaicomo"
+#' )
+#' jaccard_string_group(string, threshold = .2, n_bands = 90, n_gram_width = 1)
 #'
 #' @export
 #' @importFrom stats runif
 #' @importFrom utils installed.packages
 jaccard_string_group <- function(string, n_gram_width = 2, n_bands = 45, band_width = 8, threshold = .7, progress = FALSE) {
+  if (system.file(package = "igraph") == "") {
+    stop("library 'igraph' must be installed to run this function")
+  }
 
-    if (system.file(package = "igraph")=="") {
-            stop("library 'igraph' must be installed to run this function")
-    }
-
-    pairs <- rust_jaccard_join(string,
-                           string,
-                           ngram_width = n_gram_width,
-                           n_bands,
-                           band_size = band_width,
-                           threshold = threshold,
-                           progress = progress,
-                           seed = round(stats::runif(1,0,2^64))
-    )
-
-
-    graph <- igraph::graph_from_edgelist(pairs)
-    if (packageVersion("igraph") < "2.0.0") {
-        fc <- igraph::fastgreedy.community(igraph::as.undirected(graph))
-    } else {
-        fc <- igraph::cluster_fast_greedy(igraph::as.undirected(graph))
-    }
+  pairs <- rust_jaccard_join(string,
+    string,
+    ngram_width = n_gram_width,
+    n_bands,
+    band_size = band_width,
+    threshold = threshold,
+    progress = progress,
+    seed = round(stats::runif(1, 0, 2^64))
+  )
 
 
-    groups <- igraph::groups(fc)
-    lookup_table <- vapply(groups, "[[", integer(1), 1)
+  graph <- igraph::graph_from_edgelist(pairs)
+  if (packageVersion("igraph") < "2.0.0") {
+    fc <- igraph::fastgreedy.community(igraph::as.undirected(graph))
+  } else {
+    fc <- igraph::cluster_fast_greedy(igraph::as.undirected(graph))
+  }
 
-    membership <- igraph::membership(fc)
 
-    return(string[lookup_table[membership]])
+  groups <- igraph::groups(fc)
+  lookup_table <- vapply(groups, "[[", integer(1), 1)
+
+  membership <- igraph::membership(fc)
+
+  return(string[lookup_table[membership]])
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -143,7 +143,7 @@ I start with two corpuses I would like to combine, `corpus_1`:
 
 ```{r}
 corpus_1 <- dime_data %>%
-    head(500)
+  head(500)
 names(corpus_1) <- c("a", "field")
 corpus_1
 ```
@@ -152,7 +152,7 @@ And `corpus_2`:
 
 ```{r}
 corpus_2 <- dime_data %>%
-    tail(500)
+  tail(500)
 names(corpus_2) <- c("b", "field")
 corpus_2
 ```
@@ -177,7 +177,7 @@ vignette](https://beniamino.org/zoomerjoin/articles/guided_tour.html).
 ```{r}
 set.seed(1)
 start_time <- Sys.time()
-join_out <- jaccard_inner_join(corpus_1, corpus_2, n_gram_width=6, n_bands=20, band_width=6)
+join_out <- jaccard_inner_join(corpus_1, corpus_2, n_gram_width = 6, n_bands = 20, band_width = 6)
 print(Sys.time() - start_time)
 print(join_out)
 ```

--- a/tests/testthat/test-em_link.R
+++ b/tests/testthat/test-em_link.R
@@ -1,30 +1,28 @@
 test_that("Naive Bayes Model Achieves > 95 perecent accuracy on toy dataset", {
-    inv_logit <- function (x) {
-        exp(x)/(1+exp(x))
-    }
+  inv_logit <- function(x) {
+    exp(x) / (1 + exp(x))
+  }
 
-    for (i in 1:10) {
+  for (i in 1:10) {
+    n <- 10^5
+    d <- 1:n %% 5 == 0
+    X <- cbind(
+      as.integer(ifelse(d, runif(n) < .8, runif(n) < .2)),
+      as.integer(ifelse(d, runif(n) < .9, runif(n) < .2)),
+      as.integer(ifelse(d, runif(n) < .7, runif(n) < .2)),
+      as.integer(ifelse(d, runif(n) < .6, runif(n) < .2)),
+      as.integer(ifelse(d, runif(n) < .5, runif(n) < .2)),
+      as.integer(ifelse(d, runif(n) < .1, runif(n) < .9)),
+      as.integer(ifelse(d, runif(n) < .1, runif(n) < .9)),
+      as.integer(ifelse(d, runif(n) < .8, runif(n) < .01))
+    )
 
-        n <- 10^5
-        d <- 1:n %% 5 == 0
-        X <- cbind(
-             as.integer(ifelse(d, runif(n)<.8, runif(n)<.2)),
-             as.integer(ifelse(d, runif(n)<.9, runif(n)<.2)),
-             as.integer(ifelse(d, runif(n)<.7, runif(n)<.2)),
-             as.integer(ifelse(d, runif(n)<.6, runif(n)<.2)),
-             as.integer(ifelse(d, runif(n)<.5, runif(n)<.2)),
-             as.integer(ifelse(d, runif(n)<.1, runif(n)<.9)),
-             as.integer(ifelse(d, runif(n)<.1, runif(n)<.9)),
-             as.integer(ifelse(d, runif(n)<.8, runif(n)<.01))
-             )
+    x_sum <- rowSums(X)
+    g <- inv_logit((x_sum - mean(x_sum)) / sd(x_sum))
+    out <- em_link(X, g, tol = .0001, max_iter = 100)
 
-        x_sum <- rowSums(X)
-        g <- inv_logit((x_sum - mean(x_sum))/sd(x_sum))
-        out <- em_link(X, g,tol=.0001, max_iter = 100)
-
-        confusion_vector <- c(prop.table(table(out>.5, d)))
-        # Expect classifier gets better than  97 percent accurately reliably on toy example
-        expect_true((confusion_vector[1] + confusion_vector[4]) > .97)
-    }
-
+    confusion_vector <- c(prop.table(table(out > .5, d)))
+    # Expect classifier gets better than  97 percent accurately reliably on toy example
+    expect_true((confusion_vector[1] + confusion_vector[4]) > .97)
+  }
 })

--- a/tests/testthat/test-test_input_validation.R
+++ b/tests/testthat/test-test_input_validation.R
@@ -1,99 +1,98 @@
 library(tibble)
 a <- tribble(
-                     ~id_1, ~string,
-                     1, "beniamino green",
-                     2, "ben green",
-                     3, "jack green"
+  ~id_1, ~string,
+  1, "beniamino green",
+  2, "ben green",
+  3, "jack green"
 )
 
 b <- tribble(
-                     ~id_2, ~string,
-                     1, "teniamino green",
-                     2, "beni green",
-                     3, "gibberish"
+  ~id_2, ~string,
+  1, "teniamino green",
+  2, "beni green",
+  3, "gibberish"
 )
 
 test_that("Validates Threshold is between 0 and 1", {
-        expect_error(jaccard_inner_join(a,b, threshold = 20), regexp = "threshold.* between")
+  expect_error(jaccard_inner_join(a, b, threshold = 20), regexp = "threshold.* between")
 })
 
 test_that("Validates n_bands is positive", {
-        expect_error(jaccard_inner_join(a,b, n_bands =  -5, threshold = .99), regexp = "n_bands")
+  expect_error(jaccard_inner_join(a, b, n_bands = -5, threshold = .99), regexp = "n_bands")
 })
 
 test_that("Validates band_width is positive", {
-       expect_error(jaccard_inner_join(a,b, band_width = -5, threshold = .99), regexp = "band_width")
+  expect_error(jaccard_inner_join(a, b, band_width = -5, threshold = .99), regexp = "band_width")
 })
 
 test_that("validates n_gram_width is positive", {
-        expect_error(jaccard_inner_join(a,b, n_gram_width = -5, threshold = .99), regexp = "n_gram_width")
+  expect_error(jaccard_inner_join(a, b, n_gram_width = -5, threshold = .99), regexp = "n_gram_width")
 })
 
 test_that("Throws error when no shared columns", {
-        a2 <- a
-        names(a2) <- c('ajaaj', 'ahah')
+  a2 <- a
+  names(a2) <- c("ajaaj", "ahah")
 
-        expect_error(jaccard_inner_join(a2,b, threshold = .99), regexp = "Can't Determine")
+  expect_error(jaccard_inner_join(a2, b, threshold = .99), regexp = "Can't Determine")
 })
 
 test_that("Match Col Must be in the dataset and of length one", {
-        a2 <- a
-        names(a2) <- c('ajaaj', 'ahah')
+  a2 <- a
+  names(a2) <- c("ajaaj", "ahah")
 
-        expect_error(jaccard_inner_join(a2,a2, by = c('ajaaj', "ahah"), threshold=.99), regexp = "length 1")
-        expect_error(jaccard_inner_join(a2,b, by = c('a'="b"), threshold = .99), regexp = "by_a")
-        expect_error(jaccard_inner_join(a,b, by = c('string'="b"), threshold = .99), regexp = "by_b")
+  expect_error(jaccard_inner_join(a2, a2, by = c("ajaaj", "ahah"), threshold = .99), regexp = "length 1")
+  expect_error(jaccard_inner_join(a2, b, by = c("a" = "b"), threshold = .99), regexp = "by_a")
+  expect_error(jaccard_inner_join(a, b, by = c("string" = "b"), threshold = .99), regexp = "by_b")
 })
 
 test_that("Jaccard: using dplyr::join_by() in the 'by' argument works", {
-        expect_identical(
-                jaccard_inner_join(a, b, by = "string", band_width = 0.3),
-                jaccard_inner_join(a, b, by = dplyr::join_by(string), band_width = 0.3)
-        )
+  expect_identical(
+    jaccard_inner_join(a, b, by = "string", band_width = 0.3),
+    jaccard_inner_join(a, b, by = dplyr::join_by(string), band_width = 0.3)
+  )
 
-        a2 <- b
-        names(a2) <- c("id_2", "foobar")
-        expect_identical(
-                jaccard_inner_join(a, a2, by = c("string" = "foobar"), band_width = 0.3),
-                jaccard_inner_join(a, a2, by = dplyr::join_by(string == foobar), band_width = 0.3)
-        )
+  a2 <- b
+  names(a2) <- c("id_2", "foobar")
+  expect_identical(
+    jaccard_inner_join(a, a2, by = c("string" = "foobar"), band_width = 0.3),
+    jaccard_inner_join(a, a2, by = dplyr::join_by(string == foobar), band_width = 0.3)
+  )
 })
 
 test_that("Euclidean: using dplyr::join_by() in the 'by' argument works", {
-        n <- 10
+  n <- 10
 
-        X_1 <- matrix(c(seq(0,1,1/(n-1)), seq(0,1,1/(n-1))), nrow=n)
-        X_2 <- X_1 + .0000001
+  X_1 <- matrix(c(seq(0, 1, 1 / (n - 1)), seq(0, 1, 1 / (n - 1))), nrow = n)
+  X_2 <- X_1 + .0000001
 
-        X_1 <- as.data.frame(X_1)
-        X_2 <- as.data.frame(X_2)
+  X_1 <- as.data.frame(X_1)
+  X_2 <- as.data.frame(X_2)
 
-        X_1$id_1 <- 1:n
-        X_2$id_2 <- 1:n
+  X_1$id_1 <- 1:n
+  X_2$id_2 <- 1:n
 
-        expect_identical(
-                {
-                        res1 <- euclidean_inner_join(X_1, X_2, by = c("V1", "V2"), threshold =.00005)
-                        res1[order(res1$id_1),]
-                },
-                {
-                        res1 <- euclidean_inner_join(X_1, X_2, by = dplyr::join_by(V1, V2), threshold =.00005)
-                        res1[order(res1$id_1), ]
-                },
-                ignore_attr = TRUE # ignore row numbers
-        )
+  expect_identical(
+    {
+      res1 <- euclidean_inner_join(X_1, X_2, by = c("V1", "V2"), threshold = .00005)
+      res1[order(res1$id_1), ]
+    },
+    {
+      res1 <- euclidean_inner_join(X_1, X_2, by = dplyr::join_by(V1, V2), threshold = .00005)
+      res1[order(res1$id_1), ]
+    },
+    ignore_attr = TRUE # ignore row numbers
+  )
 
-        names(X_2) <- c("Var1", "Var2", "id_2")
-        expect_identical(
-                {
-                        res1 <- euclidean_inner_join(X_1, X_2, by = c("V1" = "Var1", "V2" = "Var2"), threshold =.00005)
-                        res1[order(res1$id_1),]
-                },
-                {
-                        res1 <- euclidean_inner_join(X_1, X_2, by = dplyr::join_by(V1 == Var1, V2 == Var2), threshold =.00005)
-                        res1[order(res1$id_1), ]
-                },
-                ignore_attr = TRUE # ignore row numbers
-        )
+  names(X_2) <- c("Var1", "Var2", "id_2")
+  expect_identical(
+    {
+      res1 <- euclidean_inner_join(X_1, X_2, by = c("V1" = "Var1", "V2" = "Var2"), threshold = .00005)
+      res1[order(res1$id_1), ]
+    },
+    {
+      res1 <- euclidean_inner_join(X_1, X_2, by = dplyr::join_by(V1 == Var1, V2 == Var2), threshold = .00005)
+      res1[order(res1$id_1), ]
+    },
+    ignore_attr = TRUE # ignore row numbers
+  )
 })
-

--- a/tests/testthat/test-test_jaccard_sim.R
+++ b/tests/testthat/test-test_jaccard_sim.R
@@ -1,18 +1,18 @@
 test_that("jaccard sim works", {
-    require(babynames)
-    require(stringdist)
+  require(babynames)
+  require(stringdist)
 
-    for (i in 1:20) {
-        nameys <- tolower(unique(babynames$name))
-        shuff_nameys <- sample(nameys, length(nameys))
+  for (i in 1:20) {
+    nameys <- tolower(unique(babynames$name))
+    shuff_nameys <- sample(nameys, length(nameys))
 
 
-        a <- 1-stringdist(nameys, shuff_nameys, q=1, method="jaccard")
-        b <- jaccard_similarity(nameys, shuff_nameys, ngram_width = 1)
-        expect_true(all(abs(a-b) < .01))
+    a <- 1 - stringdist(nameys, shuff_nameys, q = 1, method = "jaccard")
+    b <- jaccard_similarity(nameys, shuff_nameys, ngram_width = 1)
+    expect_true(all(abs(a - b) < .01))
 
-        a <- 1-stringdist(nameys, shuff_nameys, q=2, method="jaccard")
-        b <- jaccard_similarity(nameys, shuff_nameys, ngram_width = 2)
-        expect_true(all(abs(a-b) < .01))
-    }
+    a <- 1 - stringdist(nameys, shuff_nameys, q = 2, method = "jaccard")
+    b <- jaccard_similarity(nameys, shuff_nameys, ngram_width = 2)
+    expect_true(all(abs(a - b) < .01))
+  }
 })

--- a/tests/testthat/test-test_logical_euclid_join.R
+++ b/tests/testthat/test-test_logical_euclid_join.R
@@ -1,74 +1,70 @@
 test_that("euclidean_join_core works on toy datasets", {
-    capture_messages({
+  capture_messages({
+    n <- 2000
+    X_1 <- matrix(c(seq(0, 1, 1 / (n - 1)), seq(0, 1, 1 / (n - 1))), nrow = n)
+    X_2 <- X_1 + .000000000001
+    X_2 <- rbind(X_2, matrix(rep(c(2, 2), 10), nrow = 10))
 
-        n <- 2000
-        X_1 <- matrix(c(seq(0,1,1/(n-1)), seq(0,1,1/(n-1))), nrow=n)
-        X_2 <- X_1 + .000000000001
-        X_2 <- rbind(X_2, matrix(rep(c(2,2),10), nrow=10))
+    X_1 <- as.data.frame(X_1)
+    X_2 <- as.data.frame(X_2)
 
-        X_1 <- as.data.frame(X_1)
-        X_2 <- as.data.frame(X_2)
+    X_1$id_1 <- 1:n
+    X_2$id_2 <- 1:(n + 10)
 
-        X_1$id_1 <- 1:n
-        X_2$id_2 <- 1:(n+10)
+    X_1 <- as.data.frame(X_1)
+    X_2 <- as.data.frame(X_2)
 
-        X_1 <- as.data.frame(X_1)
-        X_2 <- as.data.frame(X_2)
+    inner_join_out <- euclidean_inner_join(X_1, X_2, threshold = .00005)
 
-        inner_join_out <- euclidean_inner_join(X_1, X_2, threshold =.00005)
+    expect_equal(nrow(inner_join_out), 2000)
+    expect_true(all(inner_join_out$id_1 %in% 1:2000))
+    expect_true(all(inner_join_out$id_2 %in% 1:2000))
+    expect_true(all(inner_join_out$id_1 == inner_join_out$id_2))
 
-        expect_equal(nrow(inner_join_out), 2000)
-        expect_true(all(inner_join_out$id_1 %in% 1:2000))
-        expect_true(all(inner_join_out$id_2 %in% 1:2000))
-        expect_true(all(inner_join_out$id_1 == inner_join_out$id_2))
-
-        left_join_out <- euclidean_left_join(X_1, X_2, threshold =.000005, band_width = 1)
+    left_join_out <- euclidean_left_join(X_1, X_2, threshold = .000005, band_width = 1)
 
 
-        expect_true(all(left_join_out$id_1 %in% 1:2000))
-        expect_true(all(left_join_out$id_2 %in% 1:2000))
-        expect_true(all(left_join_out$id_1 == left_join_out$id_2))
-        expect_equal(nrow(left_join_out), 2000)
+    expect_true(all(left_join_out$id_1 %in% 1:2000))
+    expect_true(all(left_join_out$id_2 %in% 1:2000))
+    expect_true(all(left_join_out$id_1 == left_join_out$id_2))
+    expect_equal(nrow(left_join_out), 2000)
 
-        right_join_out <- euclidean_right_join(X_1, X_2, threshold =.00005)
-        expect_equal(nrow(right_join_out), 2010)
-        expect_true(all(right_join_out$id_1 %in% c(1:2000,NA), na.rm =T))
-        expect_true(all(right_join_out$id_2 %in% 1:2010))
+    right_join_out <- euclidean_right_join(X_1, X_2, threshold = .00005)
+    expect_equal(nrow(right_join_out), 2010)
+    expect_true(all(right_join_out$id_1 %in% c(1:2000, NA), na.rm = T))
+    expect_true(all(right_join_out$id_2 %in% 1:2010))
 
-        outer_join_out <- euclidean_anti_join(X_1, X_2, threshold =.00005)
-        expect_equal(nrow(outer_join_out), 10)
-        expect_true(all(outer_join_out$id_2 %in% 2000:2010))
-        expect_true(all(is.na(outer_join_out$id_1)))
+    outer_join_out <- euclidean_anti_join(X_1, X_2, threshold = .00005)
+    expect_equal(nrow(outer_join_out), 10)
+    expect_true(all(outer_join_out$id_2 %in% 2000:2010))
+    expect_true(all(is.na(outer_join_out$id_1)))
 
-        full_join_out <- euclidean_full_join(X_1, X_2, threshold =.00005)
-        expect_equal(nrow(full_join_out), 2010)
-        expect_true(all(full_join_out$id_2 %in% 1:2010))
-        expect_true(all(full_join_out$id_1 %in% c(1:2000, NA)))
-
-    })
+    full_join_out <- euclidean_full_join(X_1, X_2, threshold = .00005)
+    expect_equal(nrow(full_join_out), 2010)
+    expect_true(all(full_join_out$id_2 %in% 1:2010))
+    expect_true(all(full_join_out$id_1 %in% c(1:2000, NA)))
+  })
 })
 
 
 test_that("set.seed works with Euclidean join", {
+  set.seed(1)
+  n <- 20
+  X_1 <- matrix(c(seq(0, 1, 1 / (n - 1)), seq(0, 1, 1 / (n - 1))), nrow = n)
+  X_2 <- X_1 + .1
+  X_2 <- rbind(X_2, matrix(rep(c(2, 2), 10), nrow = 10))
+  X_1 <- as.data.frame(X_1)
+  X_2 <- as.data.frame(X_2)
+  X_1$id_1 <- 1:n
+  X_2$id_2 <- 1:(n + 10)
+  X_1 <- as.data.frame(X_1)
+  X_2 <- as.data.frame(X_2)
 
-        set.seed(1)
-        n <- 20
-        X_1 <- matrix(c(seq(0,1,1/(n-1)), seq(0,1,1/(n-1))), nrow=n)
-        X_2 <- X_1 + .1
-        X_2 <- rbind(X_2, matrix(rep(c(2,2),10), nrow=10))
-        X_1 <- as.data.frame(X_1)
-        X_2 <- as.data.frame(X_2)
-        X_1$id_1 <- 1:n
-        X_2$id_2 <- 1:(n+10)
-        X_1 <- as.data.frame(X_1)
-        X_2 <- as.data.frame(X_2)
-
-        for (i in 1:20){
-            set.seed(i)
-            suppressWarnings(out_1 <- euclidean_inner_join(X_1, X_2, threshold =5))
-            set.seed(i)
-            suppressWarnings(out_2 <- euclidean_inner_join(X_1, X_2, threshold =5))
-            expect_equal(colSums(out_1), colSums(out_2))
-        }
-
+  for (i in 1:20) {
+    set.seed(i)
+    suppressWarnings(out_1 <- euclidean_inner_join(X_1, X_2, threshold = 5))
+    set.seed(i)
+    suppressWarnings(out_2 <- euclidean_inner_join(X_1, X_2, threshold = 5))
+    expect_equal(colSums(out_1), colSums(out_2))
+  }
 })

--- a/tests/testthat/test-test_logical_lsh_join.R
+++ b/tests/testthat/test-test_logical_lsh_join.R
@@ -1,163 +1,160 @@
 capture_messages({
-    require(tibble)
-    require(dplyr)
-    require(babynames)
-    require(fuzzyjoin)
-    require(stringdist)
+  require(tibble)
+  require(dplyr)
+  require(babynames)
+  require(fuzzyjoin)
+  require(stringdist)
 })
 
 dataset_1 <- tribble(
-                     ~id_1, ~string,
-                     1, "beniamino green",
-                     2, "ben green",
-                     3, "jack green"
+  ~id_1, ~string,
+  1, "beniamino green",
+  2, "ben green",
+  3, "jack green"
 ) %>%
-as.data.frame()
+  as.data.frame()
 dataset_2 <- tribble(
-                     ~id_2, ~string,
-                     1, "teniamino green",
-                     2, "beni green",
-                     3, "gibberish"
+  ~id_2, ~string,
+  1, "teniamino green",
+  2, "beni green",
+  3, "gibberish"
 ) %>%
-as.data.frame()
+  as.data.frame()
 
 
 
 misspell <- function(name) {
-    nch <- nchar(name)
-    idx <- sample(1:nch,1)
-    substr(name,idx,idx) <- "*"
-    name
+  nch <- nchar(name)
+  idx <- sample(1:nch, 1)
+  substr(name, idx, idx) <- "*"
+  name
 }
 misspell <- Vectorize(misspell)
 
 names_df <- tibble(
-    name = tolower(unique(babynames$name)),
-    id_1 = 1:n_distinct(babynames$name)
-       ) %>%
-filter(nchar(name)>9) %>%
-filter(row_number()<500)
+  name = tolower(unique(babynames$name)),
+  id_1 = 1:n_distinct(babynames$name)
+) %>%
+  filter(nchar(name) > 9) %>%
+  filter(row_number() < 500)
 
 misspelled_name_df <- names_df %>%
-    rename(id_2 = id_1) %>%
-    mutate(
-           name = misspell(name),
-    )
+  rename(id_2 = id_1) %>%
+  mutate(
+    name = misspell(name),
+  )
 
 test_that("jaccard_inner_join works on tiny dataset", {
-    capture_messages(
-        test <- jaccard_inner_join(dataset_1, dataset_2, threshold=.6, n_bands=300)
-    )
+  capture_messages(
+    test <- jaccard_inner_join(dataset_1, dataset_2, threshold = .6, n_bands = 300)
+  )
 
-    expect_true(all(test$id_1 == test$id_2, na.rm=T))
+  expect_true(all(test$id_1 == test$id_2, na.rm = T))
 
-    expect_identical(sort(test$id_1), c(1,2))
-    expect_identical(sort(test$id_2), c(1,2))
-
+  expect_identical(sort(test$id_1), c(1, 2))
+  expect_identical(sort(test$id_2), c(1, 2))
 })
 test_that("jaccard_full_join works on tiny dataset", {
-    capture_messages(
-        test <- jaccard_full_join(dataset_1, dataset_2, threshold=.6, n_bands=300)
-    )
+  capture_messages(
+    test <- jaccard_full_join(dataset_1, dataset_2, threshold = .6, n_bands = 300)
+  )
 
-    expect_true(all(test$id_1 == test$id_2, na.rm=T))
+  expect_true(all(test$id_1 == test$id_2, na.rm = T))
 
-    expect_identical(sort(test$id_1), c(1,2,3))
-    expect_identical(sort(test$id_2), c(1,2,3))
-
+  expect_identical(sort(test$id_1), c(1, 2, 3))
+  expect_identical(sort(test$id_2), c(1, 2, 3))
 })
 test_that("jaccard_left_join works on tiny dataset", {
-    capture_messages(
-        test <- jaccard_left_join(dataset_1, dataset_2, threshold=.6, n_bands=300)
-    )
+  capture_messages(
+    test <- jaccard_left_join(dataset_1, dataset_2, threshold = .6, n_bands = 300)
+  )
 
-    expect_true(all(test$id_1 == test$id_2, na.rm=T))
+  expect_true(all(test$id_1 == test$id_2, na.rm = T))
 
-    expect_identical(sort(test$id_1), c(1,2,3))
-    expect_identical(sort(test$id_2), c(1,2))
-
+  expect_identical(sort(test$id_1), c(1, 2, 3))
+  expect_identical(sort(test$id_2), c(1, 2))
 })
 test_that("jaccard_right_join works on tiny dataset", {
-    capture_messages(
-        test <- jaccard_right_join(dataset_1, dataset_2, threshold=.6, n_bands=300)
-                     )
+  capture_messages(
+    test <- jaccard_right_join(dataset_1, dataset_2, threshold = .6, n_bands = 300)
+  )
 
 
-    expect_true(all(test$id_1 == test$id_2, na.rm=T))
+  expect_true(all(test$id_1 == test$id_2, na.rm = T))
 
-    expect_identical(sort(test$id_1), c(1,2))
-    expect_identical(sort(test$id_2), c(1,2,3))
+  expect_identical(sort(test$id_1), c(1, 2))
+  expect_identical(sort(test$id_2), c(1, 2, 3))
 })
 
 test_that("jaccard_inner_join gives same results as stringdist_inner_join", {
-    for (i in 1:20) {
+  for (i in 1:20) {
     capture_messages({
-
-    zoomer_join_out <- jaccard_inner_join(names_df, misspelled_name_df, n_gram_width = 1, threshold = .9, n_bands=150, band_width = 5) %>%
-            arrange(id_1, id_2)
-
-    stringdist_join_out <- stringdist_inner_join(names_df, misspelled_name_df, method="jaccard", max_dist=.1) %>%
+      zoomer_join_out <- jaccard_inner_join(names_df, misspelled_name_df, n_gram_width = 1, threshold = .9, n_bands = 150, band_width = 5) %>%
         arrange(id_1, id_2)
 
+      stringdist_join_out <- stringdist_inner_join(names_df, misspelled_name_df, method = "jaccard", max_dist = .1) %>%
+        arrange(id_1, id_2)
     })
 
     expect_true(all.equal(zoomer_join_out, stringdist_join_out))
 
-    zoomer_join_out <- jaccard_inner_join(names_df, misspelled_name_df, n_gram_width = 1, threshold = .9, n_bands=150, band_width = 5, similarity_column = "sim")
-    expect_equal(zoomer_join_out$sim, jaccard_similarity(zoomer_join_out$name.x, zoomer_join_out$name.y, ngram_width=1))
-    }
+    zoomer_join_out <- jaccard_inner_join(names_df, misspelled_name_df, n_gram_width = 1, threshold = .9, n_bands = 150, band_width = 5, similarity_column = "sim")
+    expect_equal(zoomer_join_out$sim, jaccard_similarity(zoomer_join_out$name.x, zoomer_join_out$name.y, ngram_width = 1))
+  }
 })
 
 test_that("Blocking Functionality works correctly for jaccard_inner_join", {
-      joined_block_on_one <- jaccard_inner_join(iris, iris, by = c("Species"), block_by = "Petal.Width", n_bands = 190)
+  joined_block_on_one <- jaccard_inner_join(iris, iris, by = c("Species"), block_by = "Petal.Width", n_bands = 190)
 
-      expect_equal(joined_block_on_one$Petal.Width.y, joined_block_on_one$Petal.Width.x)
+  expect_equal(joined_block_on_one$Petal.Width.y, joined_block_on_one$Petal.Width.x)
 
-      joined_block_on_two <- jaccard_inner_join(iris, iris, by = c("Species"), block_by = c("Petal.Width", "Sepal.Width"), n_bands = 190)
+  joined_block_on_two <- jaccard_inner_join(iris, iris, by = c("Species"), block_by = c("Petal.Width", "Sepal.Width"), n_bands = 190)
 
-      expect_equal(joined_block_on_two$Petal.Width.y, joined_block_on_two$Petal.Width.x)
-      expect_equal(joined_block_on_two$Sepal.Width.y, joined_block_on_two$Sepal.Width.x)
+  expect_equal(joined_block_on_two$Petal.Width.y, joined_block_on_two$Petal.Width.x)
+  expect_equal(joined_block_on_two$Sepal.Width.y, joined_block_on_two$Sepal.Width.x)
 })
 
 test_that("seed works for jaccard joins", {
-    for (i in 1:15) {
-        set.seed(i)
-        suppressWarnings(
-            a <- jaccard_inner_join(
-                          names_df, misspelled_name_df,
-                          by  = "name",
-                          n_gram_width = 1, threshold = .3,
-                          n_bands = 1, band_width = 5
-                          ) %>%
-            arrange(id_1) %>%
-            pull(id_1)
-        )
+  for (i in 1:15) {
+    set.seed(i)
+    suppressWarnings(
+      a <- jaccard_inner_join(
+        names_df, misspelled_name_df,
+        by = "name",
+        n_gram_width = 1, threshold = .3,
+        n_bands = 1, band_width = 5
+      ) %>%
+        arrange(id_1) %>%
+        pull(id_1)
+    )
 
-        set.seed(i)
-        suppressWarnings(
-            b <- jaccard_inner_join(
-                          names_df, misspelled_name_df,
-                          by  = "name",
-                          n_gram_width = 1, threshold = .3,
-                          n_bands = 1, band_width = 5
-                          ) %>%
-            arrange(id_1) %>%
-            pull(id_1)
-        )
+    set.seed(i)
+    suppressWarnings(
+      b <- jaccard_inner_join(
+        names_df, misspelled_name_df,
+        by = "name",
+        n_gram_width = 1, threshold = .3,
+        n_bands = 1, band_width = 5
+      ) %>%
+        arrange(id_1) %>%
+        pull(id_1)
+    )
 
-        expect_equal(a,b)
-    }
+    expect_equal(a, b)
+  }
 })
 
 test_that("argument `progress` works correctly", {
   expect_silent(
     jaccard_inner_join(
-      dataset_1, dataset_2, by = "string", threshold = .6, n_bands = 300
+      dataset_1, dataset_2,
+      by = "string", threshold = .6, n_bands = 300
     )
   )
   expect_output(
     jaccard_inner_join(
-      dataset_1, dataset_2, by = "string", threshold = .6, n_bands = 300,
+      dataset_1, dataset_2,
+      by = "string", threshold = .6, n_bands = 300,
       progress = TRUE
     ),
     "generating"

--- a/tests/testthat/test-test_lsh_properties.R
+++ b/tests/testthat/test-test_lsh_properties.R
@@ -1,32 +1,31 @@
 test_that("jaccard_probabilitiy gives right results", {
-    expect_equal(jaccard_probability(.1,1,1),.1)
-    expect_equal(jaccard_probability(.2,1,1),.2)
-    expect_equal(jaccard_probability(.8,1,1),.8)
+  expect_equal(jaccard_probability(.1, 1, 1), .1)
+  expect_equal(jaccard_probability(.2, 1, 1), .2)
+  expect_equal(jaccard_probability(.8, 1, 1), .8)
 
-    expect_equal(jaccard_probability(.8,5,8),.6, tolerance =.01)
-    expect_equal(jaccard_probability(.8,5,5),.86, tolerance =.01)
+  expect_equal(jaccard_probability(.8, 5, 8), .6, tolerance = .01)
+  expect_equal(jaccard_probability(.8, 5, 5), .86, tolerance = .01)
 })
 
 test_that("jaccard_hyper_grid_search gives right results", {
-    expect_equal(
-                 jaccard_hyper_grid_search(.1,.9,.1,.9),
-                 c(band_width = 2,n_bands = 2)
-                 )
+  expect_equal(
+    jaccard_hyper_grid_search(.1, .9, .1, .9),
+    c(band_width = 2, n_bands = 2)
+  )
 
-    jaccard_hyper_grid_search(.1,.9,.1,.999)
+  jaccard_hyper_grid_search(.1, .9, .1, .999)
 
-    expect_equal(
-                 jaccard_hyper_grid_search(.1,.9,.1,.999),
-                 c(band_width = 2,n_bands = 5)
-                 )
+  expect_equal(
+    jaccard_hyper_grid_search(.1, .9, .1, .999),
+    c(band_width = 2, n_bands = 5)
+  )
 })
 test_that("jaccard_hyper_grid_search validates inputs are length 1", {
-     expect_error(jaccard_hyper_grid_search(c(.1,1),.9,.1,.9))
-     expect_error(jaccard_hyper_grid_search(1,c(1,.9),.1,.9))
-     expect_error(jaccard_hyper_grid_search(1,.9,c(.1,1),.9))
-     expect_error(jaccard_hyper_grid_search(1,.9,.1,c(.9,1)))
+  expect_error(jaccard_hyper_grid_search(c(.1, 1), .9, .1, .9))
+  expect_error(jaccard_hyper_grid_search(1, c(1, .9), .1, .9))
+  expect_error(jaccard_hyper_grid_search(1, .9, c(.1, 1), .9))
+  expect_error(jaccard_hyper_grid_search(1, .9, .1, c(.9, 1)))
 
-     expect_error(jaccard_hyper_grid_search(.9,.1,.1,.999))
-     expect_error(jaccard_hyper_grid_search(.1,.9,.9,.1))
+  expect_error(jaccard_hyper_grid_search(.9, .1, .1, .999))
+  expect_error(jaccard_hyper_grid_search(.1, .9, .9, .1))
 })
-

--- a/tests/testthat/test-test_string_group.R
+++ b/tests/testthat/test-test_string_group.R
@@ -1,15 +1,13 @@
 test_that("string_group dedups string correctly", {
-    n_groups <- purrr::map_dbl(1:30,function(x) {
-         string <- c("beniamino", "jack", "benjamin", "beniamin", "jacky")
-         dplyr::n_distinct(jaccard_string_group(string, n_bands = 190, threshold = .2))
-        }
-    )
+  n_groups <- purrr::map_dbl(1:30, function(x) {
+    string <- c("beniamino", "jack", "benjamin", "beniamin", "jacky")
+    dplyr::n_distinct(jaccard_string_group(string, n_bands = 190, threshold = .2))
+  })
 
 
-    n_groups <- purrr::map_dbl(1:30,function(x) {
-         string <- c("new haven", "new york", "chicago", "newy york")
-         dplyr::n_distinct(jaccard_string_group(string, n_bands = 190, threshold = .2))
-        }
-    )
-    expect_equal(median(n_groups),3)
+  n_groups <- purrr::map_dbl(1:30, function(x) {
+    string <- c("new haven", "new york", "chicago", "newy york")
+    dplyr::n_distinct(jaccard_string_group(string, n_bands = 190, threshold = .2))
+  })
+  expect_equal(median(n_groups), 3)
 })

--- a/vignettes/benchmarks.Rmd
+++ b/vignettes/benchmarks.Rmd
@@ -44,18 +44,19 @@ the rows in each dataset, so it becomes quicker for larger datasets.
 
 ```{r, echo=F}
 sim_data <- read_csv("sim_data.csv")
-sim_data  %>%
-    mutate(
-           name = ifelse(name == "time", "Time Usage (s)", "Memory Usage (MB)"),
-           join_type = ifelse(join_type == "Jaccard Distance",
-                              "Jaccard Distance Join",
-                              "Euclidean Distance Joins"),
-           ) %>%
-    ggplot(aes(x=as.numeric(n), y=value, col = package, linetype = package)) +
-    geom_point() +
-    geom_line() +
-    facet_wrap(~ join_type + name, scales = 'free') +
-    scale_y_continuous("Time (s) / memory (MB)")
+sim_data %>%
+  mutate(
+    name = ifelse(name == "time", "Time Usage (s)", "Memory Usage (MB)"),
+    join_type = ifelse(join_type == "Jaccard Distance",
+      "Jaccard Distance Join",
+      "Euclidean Distance Joins"
+    ),
+  ) %>%
+  ggplot(aes(x = as.numeric(n), y = value, col = package, linetype = package)) +
+  geom_point() +
+  geom_line() +
+  facet_wrap(~ join_type + name, scales = "free") +
+  scale_y_continuous("Time (s) / memory (MB)")
 ```
 
 # Benchmarking Code:
@@ -84,7 +85,7 @@ X_1 <- as.data.frame(X)
 X_2 <- as.data.frame(X + .000000001)
 
 # Get time and memory use statistics for fuzzyjoin when performing jaccard join
-fuzzy_jaccard_bench <- function(n){
+fuzzy_jaccard_bench <- function(n) {
   time <- microbenchmark(
     stringdist_inner_join(data_1[1:n, ],
       data_2[1:n, ],
@@ -171,8 +172,8 @@ zoomer_euclid_bench <- function(n) {
 # Run Grid of Jaccard Benchmarks, Collect results into DF
 n <- seq(500, 4000, 250)
 names(n) <- n
-fuzzy_jacard_benches <- map_df(n, fuzzy_jaccard_bench, .id="n")
-zoomer_jacard_benches <- map_df(n, zoomer_jaccard_bench, .id="n")
+fuzzy_jacard_benches <- map_df(n, fuzzy_jaccard_bench, .id = "n")
+zoomer_jacard_benches <- map_df(n, zoomer_jaccard_bench, .id = "n")
 fuzzy_jacard_benches$package <- "fuzzyjoin"
 zoomer_jacard_benches$package <- "zoomerjoin"
 jaccard_benches <- bind_rows(fuzzy_jacard_benches, zoomer_jacard_benches)
@@ -181,16 +182,16 @@ jaccard_benches$join_type <- "Jaccard Distance"
 # Run Grid of Euclidean Benchmarks, Collect results into DF
 n <- seq(250, 4000, 250)
 names(n) <- n
-fuzzy_euclid_benches <- map_df(n, fuzzy_euclid_bench, .id="n")
-zoomer_euclid_benches <- map_df(n, zoomer_euclid_bench, .id="n")
+fuzzy_euclid_benches <- map_df(n, fuzzy_euclid_bench, .id = "n")
+zoomer_euclid_benches <- map_df(n, zoomer_euclid_bench, .id = "n")
 fuzzy_euclid_benches$package <- "fuzzyjoin"
 zoomer_euclid_benches$package <- "zoomerjoin"
 euclid_benches <- bind_rows(fuzzy_euclid_benches, zoomer_euclid_benches)
 euclid_benches$join_type <- "Euclidean Distance"
 
 sim_data <- bind_rows(euclid_benches, jaccard_benches) %>%
-    pivot_longer(c(time, memory)) %>%
-    mutate(value = ifelse(name =="time", value / 10^9, value / 10^6)) # convert ns to s and bytes to Gb.
+  pivot_longer(c(time, memory)) %>%
+  mutate(value = ifelse(name == "time", value / 10^9, value / 10^6)) # convert ns to s and bytes to Gb.
 
 write_csv(sim_data, "sim_data.csv")
 ```

--- a/vignettes/guided_tour.Rmd
+++ b/vignettes/guided_tour.Rmd
@@ -48,7 +48,7 @@ library(fuzzyjoin)
 library(zoomerjoin)
 
 corpus_1 <- dime_data %>% # dime data is packaged with zoomerjoin
-    head(500)
+  head(500)
 names(corpus_1) <- c("a", "field")
 corpus_1
 ```
@@ -57,7 +57,7 @@ And the second looks as follows:
 
 ```{r}
 corpus_2 <- dime_data %>% # dime data is packaged with zoomerjoin
-    tail(500)
+  tail(500)
 names(corpus_2) <- c("b", "field")
 corpus_2
 ```
@@ -69,8 +69,9 @@ we must use the fuzzy-matching capabilities of zoomerjoin:
 set.seed(1)
 start_time <- Sys.time()
 join_out <- jaccard_inner_join(corpus_1, corpus_2,
-                           by = "field", n_gram_width=6,
-                           n_bands=20, band_width=6, threshold = .8)
+  by = "field", n_gram_width = 6,
+  n_bands = 20, band_width = 6, threshold = .8
+)
 print(Sys.time() - start_time)
 print(join_out)
 ```
@@ -101,7 +102,7 @@ that a pair of records are compared at each possible Jaccard distance, $d$
 between zero and one:
 
 ```{r}
-jaccard_curve(20,6)
+jaccard_curve(20, 6)
 ```
 
 By looking at the plot produced, we can see that using these hyperparameters,
@@ -134,15 +135,15 @@ standardize a set of organization names.
 
 ```{r}
 organization_names <- c(
-                        "American Civil Liberties Union",
-                        "American Civil Liberties Union (ACLU)",
-                        "NRA National Rifle Association",
-                        "National Rifle Association NRA",
-                        "National Rifle Association",
-                        "Planned Parenthood",
-                        "Blue Cross"
+  "American Civil Liberties Union",
+  "American Civil Liberties Union (ACLU)",
+  "NRA National Rifle Association",
+  "National Rifle Association NRA",
+  "National Rifle Association",
+  "Planned Parenthood",
+  "Blue Cross"
 )
-standardized_organization_names <- jaccard_string_group(organization_names, threshold=.5, band_width = 3)
+standardized_organization_names <- jaccard_string_group(organization_names, threshold = .5, band_width = 3)
 print(standardized_organization_names)
 ```
 

--- a/vignettes/matching_vectors.Rmd
+++ b/vignettes/matching_vectors.Rmd
@@ -41,10 +41,10 @@ n <- 10^5 # number of data points
 d <- 10^2 # dimension
 
 # Create a matrix of 10^6 observations in R^100
-X <- matrix(runif(n*d),n,d)
+X <- matrix(runif(n * d), n, d)
 # Second Dataset is a copy of the first with points shifted an infinitesimal
 # amount
-X_2 <- as.data.frame(X + matrix(rnorm(n*d, 0,.0001), n,d))
+X_2 <- as.data.frame(X + matrix(rnorm(n * d, 0, .0001), n, d))
 X <- as.data.frame(X)
 ```
 
@@ -57,14 +57,14 @@ probability that two observations at distance of .01 from each other are
 indentified as a match at a variety of hyperparameter configurations.
 
 ```{r}
-euclidean_probability(.01, n_bands = 5,band_width = 8,r = .25)
-euclidean_probability(.1, n_bands = 5,band_width = 8,r = .25)
+euclidean_probability(.01, n_bands = 5, band_width = 8, r = .25)
+euclidean_probability(.1, n_bands = 5, band_width = 8, r = .25)
 
-euclidean_probability(.01, n_bands = 10,band_width = 4,r = .15)
-euclidean_probability(.1, n_bands = 10,band_width = 4,r = .15)
+euclidean_probability(.01, n_bands = 10, band_width = 4, r = .15)
+euclidean_probability(.1, n_bands = 10, band_width = 4, r = .15)
 
-euclidean_probability(.01, n_bands = 40,band_width = 8,r = .15)
-euclidean_probability(.1, n_bands = 40,band_width = 8,r = .15)
+euclidean_probability(.01, n_bands = 40, band_width = 8, r = .15)
+euclidean_probability(.1, n_bands = 40, band_width = 8, r = .15)
 ```
 
 Using `n_bands=40`, `band_width=8`, and `r=.15` seems to provide a good balance
@@ -78,12 +78,13 @@ guaranteed to be found) with reducing the number of un-promising comparisons
 set.seed(1)
 start <- Sys.time()
 joined_out <- euclidean_inner_join(
-                     X,
-                     X_2,
-                     threshold = .01,
-                     n_bands = 40,
-                     band_width = 8,
-                     r=.15)
+  X,
+  X_2,
+  threshold = .01,
+  n_bands = 40,
+  band_width = 8,
+  r = .15
+)
 n_matches <- nrow(joined_out)
 time_taken <- Sys.time() - start
 print(paste("found", n_matches, "matches in", round(time_taken), "seconds"))


### PR DESCRIPTION
This is useful to improve the readability of the code and docs (spaces after commas, consistent indentation, etc.).

I think this could be merged as-is, but the default indentation changed. @beniaminogreen do you have preferences for indentation? If you want a different indentation, you can run `styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 6L))` (and replace `6L` by your preferred indentation).