### PR TITLE
CI: make R CMD check fail on warning

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          error-on: '"error"'
+          error-on: '"warning"'
 
       - name: debug install
         if: always()


### PR DESCRIPTION
This would allow to catch warnings in R CMD check more easily. For example, for now there are 2 undocumented arguments:

![image](https://github.com/beniaminogreen/zoomerjoin/assets/52219252/e8b2151a-2dc1-41b4-ae94-94e63097583a)

@beniaminogreen I'll let you merge this one if you're ok with that 