### PR TITLE
bugfix

### DIFF
--- a/R/join_core.R
+++ b/R/join_core.R
@@ -16,7 +16,7 @@ multi_by_validate <- function(a, b, by) {
   } else {
     if (!is.null(names(by))) {
       by_a <- names(by)
-      by_b <- by
+      by_b <- unname(by)
     } else {
       by_a <- by
       by_b <- by


### PR DESCRIPTION
This fixes the bug in #135, which happened because the 'block_by' argument was being passed to `tidyr::unite` without stripping the name.